### PR TITLE
Fix ReferenceError: success is not defined

### DIFF
--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -11,10 +11,10 @@ module.exports = {
     setUserProperty: function(name, value, success, error) {
         exec(success, error, PLUGIN_NAME, "setUserProperty", [name, value]);
     },
-    setEnabled: function(enabled) {
+    setEnabled: function(enabled, success, error) {
         exec(success, error, PLUGIN_NAME, "setEnabled", [String(enabled !== false)]);
     },
-    setCurrentScreen: function(name) {
+    setCurrentScreen: function(name, success, error) {
         exec(success, error, PLUGIN_NAME, "setCurrentScreen", [name]);
     }
 };


### PR DESCRIPTION
Fix `success` and `error` not being defined for the methods `setEnabled` and `setCurrentScreen`.