### PR TITLE
Will no longer depend on cordova-plugin-cocoapods-support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </js-module>
 
     <engines>
-        <engine name="cordova" version=">=3.5.0"/>
+        <engine name="cordova" version=">=6.4.0"/>
+        <engine name="cordova-android" version=">=6.0.0"/>
+        <engine name="cordova-ios" version=">=4.3.0"/>
     </engines>
 
     <dependency id="cordova-plugin-firebase-hooks"/>
@@ -31,7 +33,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
-        <pod id="Firebase/Analytics" />
+        <framework src="FirebaseAnalytics" type="podspec" spec="~> 3.9"/>
     </platform>
 
     <platform name="android">


### PR DESCRIPTION
..since `cordova-ios` >=4.3.0 has it’s own support for that