### PR TITLE
fixes reading GoogleService-Info.plist on iOS

### DIFF
--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -8,9 +8,12 @@
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase Analytics plugin");
 
-    if(![FIRApp defaultApp]) {
-        [FIRApp configure];
-    }
+    // Get the path for Google-Service-Info.plist
+    NSString * filePath =[[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType: @"plist"];
+
+    // Init FIRApp passing the file
+    FIROptions * options =[[FIROptions alloc] initWithContentsOfFile: filePath];
+    [FIRApp configureWithOptions: options];
 }
 
 - (void)logEvent:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
I was getting this error before this pull-request:

```
[Firebase/Core][I-COR000003] The default Firebase app has not yet been configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your application initialization. Read more: https://goo.gl/ctyzm8.
```

People from `cordova-plugin-firebase` were having the same problem, which I've got the fix from here: https://github.com/arnesson/cordova-plugin-firebase/issues/866#issuecomment-424746635

This fix has been merged on `cordova-plugin-firebase` project, and can be observed here: https://github.com/arnesson/cordova-plugin-firebase/blob/db3b661fc7fe23694794c9d4e8f9f10c8eb7d649/src/ios/AppDelegate%2BFirebasePlugin.m#L51-L61