### PR TITLE
Bump cordova-support-google-services to v1.3.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-        <dependency id="cordova-support-google-services" version="^1.2.0"/>
+        <dependency id="cordova-support-google-services" version="^1.3.1"/>
 
         <framework src="com.google.firebase:firebase-core:$FIREBASE_CORE_VERSION" />
 


### PR DESCRIPTION
The current version (1.1.1) results in the following error: 
```
Failed to install 'cordova-plugin-firebase-analytics': 
CordovaError: Cannot find plugin.xml for plugin "cordova-support-google-services". 
Please try adding it again.
```
