### PR TITLE
Update cordova-support-google-services dependency to fix  build error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-        <dependency id="cordova-support-google-services" version="^1.3.0"/>
+        <dependency id="cordova-support-google-services" version="^1.3.2"/>
 
         <framework src="com.google.firebase:firebase-core:$FIREBASE_CORE_VERSION" />
 


### PR DESCRIPTION
The currently used version of the `cordova-support-google-services` plugin (version 1.3.0) produces an error 

> Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.60-eap-25

when building for Android.

This error has been fixed in version 1.3.2.

See https://github.com/chemerisuk/cordova-support-google-services/pull/26 for details.