### PR TITLE
Added screenClass parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ cordova.plugins.firebase.analytics.setUserProperty("name1", "value1");
 
 Be aware of [automatically collected user properties](https://support.google.com/firebase/answer/6317486?hl=en&ref_topic=6317484).
 
-### setCurrentScreen(_name_)
-Sets the current screen name, which specifies the current visual context in your app. This helps identify the areas in your app where users spend their time and how they interact with your app.
+### setCurrentScreen(_screenName_, _screenClass_)
+Sets the current screen name and screen class, which specifies the current visual context in your app. This helps identify the areas in your app where users spend their time and how they interact with your app.
 ```js
 cordova.plugins.firebase.analytics.setCurrentScreen("User profile");
 ```

--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -86,11 +86,11 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
     }
 
     @CordovaMethod(ExecutionThread.UI)
-    private void setCurrentScreen(String screenName, CallbackContext callbackContext) {
+    private void setCurrentScreen(String screenName, String screenClass, CallbackContext callbackContext) {
         firebaseAnalytics.setCurrentScreen(
             cordova.getActivity(),
             screenName,
-            null
+            screenClass
         );
 
         callbackContext.success();

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -52,9 +52,10 @@
 }
 
 - (void)setCurrentScreen:(CDVInvokedUrlCommand *)command {
-    NSString* name = [command.arguments objectAtIndex:0];
+    NSString* screenName = [command.arguments objectAtIndex:0];
+    NSString* screenClass = [command.arguments objectAtIndex:1];
 
-    [FIRAnalytics setScreenName:name screenClass:nil];
+    [FIRAnalytics setScreenName:screenName screenClass:screenClass];
 
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -35,9 +35,12 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setEnabled", [enabled]);
         });
     },
-    setCurrentScreen: function(name) {
+    setCurrentScreen: function(screenName, screenClass) {
+        if (typeof screenClass !== "string") {
+            screenClass = screenName;
+        }
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, PLUGIN_NAME, "setCurrentScreen", [name]);
+            exec(resolve, reject, PLUGIN_NAME, "setCurrentScreen", [screenName, screenClass]);
         });
     }
 };


### PR DESCRIPTION
For cordova apps the screen class is always set to MainActivity or MainViewController which is technically right, but from user perspective does not give much sense. For that reason I propose this PR that adds possibility to either specify custom screenClass or set it to screenName.
Thank you for taking case about this very useful plugin and feel free this PR to merge, deny or we can discuss.
--- Jaroslav
