### PR TITLE
Fix version and imports - iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -42,11 +42,14 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
-
+ 
         <podspec>
             <config>
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
+            <pods>
+                <pod name="Firebase/Analytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
+            </pods>
         </podspec>
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,9 +47,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <config>
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
-            <pods>
-                <pod name="Firebase/Analytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
-            </pods>
         </podspec>
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Firebase/Analytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
+                <pod name="Firebase/Analytics" />
             </pods>
         </podspec>
     </platform>

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -1,6 +1,6 @@
 #import "FirebaseAnalyticsPlugin.h"
 
-@import Firebase;
+@import FirebaseAnalytics;
 
 
 @implementation FirebaseAnalyticsPlugin

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -1,6 +1,7 @@
 #import "FirebaseAnalyticsPlugin.h"
 
 @import FirebaseAnalytics;
+#import "FIRApp.h"
 
 
 @implementation FirebaseAnalyticsPlugin


### PR DESCRIPTION
 These small changes solve the problems that are happening on iOS. Which are in relation to the version and imports.

The spec was removed so that cocoapods can suggest the correct version and the import that was crashing during the build was adjusted.


### Related Issues
- https://github.com/chemerisuk/cordova-plugin-firebase-analytics/issues/168
