### PR TITLE
Supporting e-commerce items (i.e. products) for Google Analytics

### DIFF
--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -10,9 +10,11 @@ import by.chemerisuk.cordova.support.ReflectiveCordovaPlugin;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 
 
@@ -97,8 +99,15 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
                 bundle.putDouble(key, (Double)value);
             } else if (value instanceof Long) {
                 bundle.putLong(key, (Long)value);
+            } else if (value instanceof JSONArray) {
+                JSONArray jsonArray = (JSONArray)value;
+                ArrayList<Bundle> items = new ArrayList<Bundle>();
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    items.add(parse((JSONObject)jsonArray.get(i)));
+                }
+                bundle.putParcelableArrayList(key, items);
             } else {
-                Log.w(TAG, "Value for key " + key + " not one of (String, Integer, Double, Long)");
+                Log.w(TAG, "Value for key " + key + " not one of (String, Integer, Double, Long, JSONArray)");
             }
         }
 


### PR DESCRIPTION

Firebase Analytics supports [Measure Ecommerce](https://firebase.google.com/docs/analytics/measure-ecommerce),

Which allows measurement of user interactions with products across your users' shopping experiences, including interactions such as product (item) list views, product list clicks, viewing product details, adding a product to a shopping cart, initiating the checkout process, purchases, and refunds.

**Problem Statement:**
In Android, we are parsing the params & only allowing (String, Integer, Double, Long) not the items (i.e. products) array.

**Solution**
Now we are allowing a valid JSONArray, which sends the items (i.e. products) along with e-commerce event params.
