### PR TITLE
getAppInstanceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Callback when operation is completed
 
 ### getAppInstanceId
 
-**getAppInstanceId**(): `Promise`<`{appInstanceId: string}`\>
+**getAppInstanceId**(): `Promise`<`string`\>
 
 Returns app instance identifier from Firebase.
 
@@ -292,6 +292,6 @@ cordova.plugins.firebase.analytics.getAppInstanceId();
 
 #### Returns
 
-`Promise`<`{appInstanceId: string}`\>
+`Promise`<`string`\>
 
 Callback when operation is completed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     - [setEnabled](#setenabled)
     - [setUserId](#setuserid)
     - [setUserProperty](#setuserproperty)
+    - [getAppInstanceId](#getappinstanceid)
 
 <!-- /MarkdownTOC -->
 
@@ -274,5 +275,23 @@ cordova.plugins.firebase.analytics.setUserProperty("name1", "value1");
 #### Returns
 
 `Promise`<`void`\>
+
+Callback when operation is completed
+
+### getAppInstanceId
+
+**getAppInstanceId**(): `Promise`<`{appInstanceId: string}`\>
+
+Returns app instance identifier from Firebase.
+
+**`Example`**
+
+```ts
+cordova.plugins.firebase.analytics.getAppInstanceId();
+```
+
+#### Returns
+
+`Promise`<`{appInstanceId: string}`\>
 
 Callback when operation is completed

--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -87,13 +87,7 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
         firebaseAnalytics.getAppInstanceId()
             .addOnCompleteListener(task -> {
                 if (task.isSuccessful()) {
-                    try {
-                        JSONObject result = new JSONObject();
-                        result.put("appInstanceId", task.getResult());
-                        callbackContext.success(result);
-                    } catch (JSONException e) {
-                        callbackContext.error(e.getMessage());
-                    }
+                    callbackContext.success(task.getResult());
                 } else {
                     callbackContext.error(task.getException().getMessage());
                 }

--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -82,6 +82,24 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
         callbackContext.success();
     }
 
+    @CordovaMethod
+    protected void getAppInstanceId(CordovaArgs args, CallbackContext callbackContext) {
+        firebaseAnalytics.getAppInstanceId()
+            .addOnCompleteListener(task -> {
+                if (task.isSuccessful()) {
+                    try {
+                        JSONObject result = new JSONObject();
+                        result.put("appInstanceId", task.getResult());
+                        callbackContext.success(result);
+                    } catch (JSONException e) {
+                        callbackContext.error(e.getMessage());
+                    }
+                } else {
+                    callbackContext.error(task.getException().getMessage());
+                }
+            });
+    }
+
     private static Bundle parse(JSONObject params) throws JSONException {
         Bundle bundle = new Bundle();
         Iterator<String> it = params.keys();

--- a/src/ios/FirebaseAnalyticsPlugin.h
+++ b/src/ios/FirebaseAnalyticsPlugin.h
@@ -9,5 +9,6 @@
 - (void)setCurrentScreen:(CDVInvokedUrlCommand*)command;
 - (void)resetAnalyticsData:(CDVInvokedUrlCommand*)command;
 - (void)setDefaultEventParameters:(CDVInvokedUrlCommand*)command;
+- (void)getAppInstanceId:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -78,4 +78,12 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)getAppInstanceId:(CDVInvokedUrlCommand *)command {
+    NSString* appInstanceId = [FIRAnalytics appInstanceID];
+    NSDictionary* result = @{@"appInstanceId": appInstanceId};
+    
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -80,9 +80,8 @@
 
 - (void)getAppInstanceId:(CDVInvokedUrlCommand *)command {
     NSString* appInstanceId = [FIRAnalytics appInstanceID];
-    NSDictionary* result = @{@"appInstanceId": appInstanceId};
     
-    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:appInstanceId];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 

--- a/types/FirebaseAnalytics.d.ts
+++ b/types/FirebaseAnalytics.d.ts
@@ -72,3 +72,12 @@ export function setCurrentScreen(screenName: string): Promise<void>;
  * cordova.plugins.firebase.analytics.setDefaultEventParameters({foo: "bar"});
  */
 export function setDefaultEventParameters(defaults: Record<string, number | string | Array<object>>): Promise<void>;
+/**
+ * Returns app instance identifier from Firebase.
+ *
+ * @returns {Promise<string>} Callback when operation is completed
+ *
+ * @example
+ * cordova.plugins.firebase.analytics.getAppInstanceId();
+ */
+export function getAppInstanceId(): Promise<string>;

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -117,3 +117,18 @@ function(defaults) {
         exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
     });
 };
+
+exports.getAppInstanceId =
+/**
+ * Returns app instance identifier from Firebase.
+ *
+ * @returns {Promise<{appInstanceId: string}>} Callback when operation is completed
+ *
+ * @example
+ * cordova.plugins.firebase.analytics.getAppInstanceId();
+ */
+function() {
+    return new Promise(function(resolve, reject) {
+        exec(resolve, reject, PLUGIN_NAME, "getAppInstanceId", []);
+    });
+};

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -122,13 +122,15 @@ exports.getAppInstanceId =
 /**
  * Returns app instance identifier from Firebase.
  *
- * @returns {Promise<{appInstanceId: string}>} Callback when operation is completed
+ * @returns {Promise<string>} Callback when operation is completed
  *
  * @example
  * cordova.plugins.firebase.analytics.getAppInstanceId();
  */
 function() {
     return new Promise(function(resolve, reject) {
-        exec(resolve, reject, PLUGIN_NAME, "getAppInstanceId", []);
+        exec(function(result) {
+            resolve(result.appInstanceId);
+        }, reject, PLUGIN_NAME, "getAppInstanceId", []);
     });
 };

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -129,8 +129,6 @@ exports.getAppInstanceId =
  */
 function() {
     return new Promise(function(resolve, reject) {
-        exec(function(result) {
-            resolve(result.appInstanceId);
-        }, reject, PLUGIN_NAME, "getAppInstanceId", []);
+        exec(resolve, reject, PLUGIN_NAME, "getAppInstanceId", []);
     });
 };


### PR DESCRIPTION
Added method `getAppInstanceId()`

to be able to set `app_instance_id` from this spec: https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase